### PR TITLE
Remove incorrect done callback

### DIFF
--- a/list-objects.js
+++ b/list-objects.js
@@ -19,7 +19,7 @@ if (!argv.buckets) {
 var buckets = argv.buckets.split(",")
 buckets.forEach(function(bucketName) {
    s3.listObjects({Bucket:bucketName}).eachPage(
-   function(err, data, done) {
+   function(err, data) {
       if (err) {
          console.error(err);
          process.exit(1);
@@ -29,7 +29,6 @@ buckets.forEach(function(bucketName) {
             process.stdout.write(bucketName + ":" + object.Key + "\n");
          });
          completed += data.Contents.length;
-         if (done) stream.end();
          log("\rListed " + completed + " objects.");
       }, 0);
    });


### PR DESCRIPTION
The previous version of this function was causing an error with the
versions of dependencies installed by `npm`. This removes the done
callback so that these errors do not happen.