### PR TITLE
operations: add set-acl to set object ACLs

### DIFF
--- a/modify-headers.js
+++ b/modify-headers.js
@@ -2,7 +2,7 @@ var AWS = require('aws-sdk');
 var _ = require('underscore');
 var s3 = new AWS.S3({apiVersion: '2006-03-01'});
 
-module.exports = function(headerTransformer) {
+module.exports = function modifyHeadersFactory(headerTransformer) {
    return function fixObjectHeaders(bucket, key, callback) {
       modifyHeaders(bucket, key, headerTransformer,
       function(err, response, original, fixed) {

--- a/modify-headers.js
+++ b/modify-headers.js
@@ -2,7 +2,23 @@ var AWS = require('aws-sdk');
 var _ = require('underscore');
 var s3 = new AWS.S3({apiVersion: '2006-03-01'});
 
-module.exports = function(bucket, key, headerTransformer, callback) {
+module.exports = function(headerTransformer) {
+   return function fixObjectHeaders(bucket, key, callback) {
+      modifyHeaders(bucket, key, headerTransformer,
+      function(err, response, original, fixed) {
+         if (err) {
+            console.log("FAILURE:%s:%s", bucket,key);
+         } else {
+            console.log("SUCCESS:%s:%s before:%s", bucket, key, JSON.stringify(original));
+            console.log("               after:%s", JSON.stringify(fixed));
+         }
+         callback(err);
+      });
+   }
+}
+
+
+function modifyHeaders(bucket, key, headerTransformer, callback) {
    s3.headObject({Bucket: bucket, Key: key}, function(err, headers) {
       if (err) {
          return callback(err);
@@ -27,7 +43,7 @@ module.exports = function(bucket, key, headerTransformer, callback) {
          callback(err, response, headers, newHeaders);
       });
    });
-};
+}
 
 function removeDisallowedHeaders(headers) {
    delete headers.AcceptRanges;

--- a/operations/fix-cache-headers.js
+++ b/operations/fix-cache-headers.js
@@ -1,6 +1,6 @@
-var modifyHeaders = require('../modify-headers.js');
+var modifyHeadersFactory = require('../modify-headers.js');
 
-module.exports = modifyHeaders(function fixCacheHeaders(headers) {
+module.exports = modifyHeadersFactory(function fixCacheHeaders(headers) {
    delete headers.Expires;
    headers.CacheControl = 'max-age=31557600';
    return headers;

--- a/operations/fix-cache-headers.js
+++ b/operations/fix-cache-headers.js
@@ -1,6 +1,8 @@
-module.exports = function fixCacheHeaders(headers) {
+var modifyHeaders = require('../modify-headers.js');
+
+module.exports = modifyHeaders(function fixCacheHeaders(headers) {
    delete headers.Expires;
    headers.CacheControl = 'max-age=31557600';
    return headers;
-}
+});
 

--- a/operations/make-private.js
+++ b/operations/make-private.js
@@ -1,6 +1,6 @@
-var setAcl = require('../set-acl.js');
+var setAclFactory = require('../set-acl.js');
 
-module.exports = setAcl(function getAcl(bucket, key) {
+module.exports = setAclFactory(function getAcl(bucket, key) {
    return {ACL: 'private'};
 });
 

--- a/operations/make-private.js
+++ b/operations/make-private.js
@@ -1,0 +1,6 @@
+var setAcl = require('../set-acl.js');
+
+module.exports = setAcl(function getAcl(bucket, key) {
+   return {ACL: 'private'};
+});
+

--- a/set-acl.js
+++ b/set-acl.js
@@ -21,6 +21,6 @@ function putObjectAcl(bucket, key, acl, callback) {
    acl.Bucket = bucket;
    acl.Key = key;
    s3.putObjectAcl(acl, function(err) {
-      return callback(err);
+      callback(err);
    });
 }

--- a/set-acl.js
+++ b/set-acl.js
@@ -1,0 +1,26 @@
+var AWS = require('aws-sdk');
+var s3 = new AWS.S3({apiVersion: '2006-03-01'});
+
+module.exports = function(getAcl) {
+   return function (bucket, key, callback) {
+      putObjectAcl(bucket, key, getAcl(bucket, key),
+      function(err) {
+         if (err) {
+            console.log("FAILURE:%s:%s", bucket, key);
+         } else {
+            console.log("SUCCESS:%s:%s", bucket, key);
+         }
+         callback(err);
+      });
+   }
+}
+
+
+function putObjectAcl(bucket, key, acl, callback) {
+   acl = acl || {};
+   acl.Bucket = bucket;
+   acl.Key = key;
+   s3.putObjectAcl(acl, function(err) {
+      return callback(err);
+   });
+}


### PR DESCRIPTION
Add set-acl for acl-setting operations to use and add
make-private.js as a simple example.

Also, refactor the modify-headers.js module slightly to utilize the new
operation format.
